### PR TITLE
GitHub workflows (Linux): upgrade compilers

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Install packages
       run: |
         sudo apt update
-        sudo apt install -y cmake ninja-build ${{ matrix.compiler.cc }}
+        sudo apt install -y cmake ninja-build ${{ matrix.compiler.packages }}
 
     - name: Configure Git to treat current directory as safe
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -32,6 +32,7 @@ on:
       - 'entity2/**'
       - 'game/server/**'
       - 'game/shared/**'
+      - 'gcsdk/**'
       - 'interfaces/**'
       - 'lib/linuxsteamrt64/**'
       - 'mathlib/**'
@@ -60,7 +61,7 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.compiler.name }}
+    name: ${{ matrix.compiler.display_name }}
     runs-on: ubuntu-latest
     container: registry.gitlab.steamos.cloud/steamrt/sniper/sdk
 
@@ -69,14 +70,20 @@ jobs:
         compiler:
           [
             {
-              name: Clang,
-              cc: clang,
-              cxx: clang++,
+              name: GCC,
+              display_name: GCC 14,
+
+              packages: gcc-14 g++-14 gcc-14-monolithic,
+              cc: gcc-14,
+              cxx: g++-14,
             },
             {
-              name: GCC,
-              cc: gcc-12,
-              cxx: g++-12,
+              name: Clang,
+              display_name: Clang 20,
+
+              packages: clang-20 gcc-14-monolithic,
+              cc: clang-20,
+              cxx: clang++-20,
             }
         ]
       fail-fast: false
@@ -88,15 +95,16 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
 
-    - name: Install dependencies
+    - name: Configure package repositories
       run: |
-        sudo apt-get update
-        sudo apt-get install -y ninja-build ${{ matrix.compiler.cc }}
+        echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-20 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+        echo "deb-src http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-20 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
 
-    - name: Set up environment variables
+    - name: Install packages
       run: |
-        echo "ABSOLUTE_PATH=$(pwd)" >> $GITHUB_ENV
-        echo "REPOSITORY_NAME=$(basename ${GITHUB_REPOSITORY})" >> $GITHUB_ENV
+        sudo apt update
+        sudo apt install -y cmake ninja-build ${{ matrix.compiler.cc }}
 
     - name: Configure Git to treat current directory as safe
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -111,6 +119,20 @@ jobs:
           LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
           echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
         fi
+
+    - name: Set up base environment variables
+      run: |
+        echo "ABSOLUTE_PATH=$(pwd)" >> $GITHUB_ENV
+        echo "REPOSITORY_NAME=$(basename ${GITHUB_REPOSITORY})" >> $GITHUB_ENV
+
+    - name: Set environment variables for Clang
+      if: matrix.compiler.name == 'Clang'
+      run: |
+        echo "CC=${{ matrix.compiler.cc }}" >> $GITHUB_ENV
+        echo "CXX=${{ matrix.compiler.cxx }}" >> $GITHUB_ENV
+        echo "CPLUS_INCLUDE_PATH=/usr/lib/gcc-14/include/c++/14:/usr/lib/gcc-14/include/c++/14/x86_64-linux-gnu:/usr/lib/gcc-14/include/c++/14/backward" >> $GITHUB_ENV
+        echo "LIBRARY_PATH=/usr/lib/gcc-14/lib/gcc/x86_64-linux-gnu/14" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=/usr/lib/gcc-14/lib/gcc/x86_64-linux-gnu/14" >> $GITHUB_ENV
 
     - name: Debug - Configure CMake
       run: >

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -54,15 +54,22 @@ env:
   CMAKE_RELEASE_BUILD_PRESET_PUBLIC_NAME: VisualStudio-Release
   CMAKE_RELEASE_OUTPUT_PATTERN: build\Windows\VisualStudio\Release\*
 
-  COMPILER_CC: cl
-  COMPILER_CXX: cl
-  COMPILER_NAME: MSVC
-
 jobs:
   build:
+    name: ${{ matrix.compiler.display_name }}
     runs-on: windows-latest
 
     strategy:
+      matrix:
+        compiler:
+          [
+            {
+              name: MSVC,
+              display_name: MSVC,
+              cc: cl,
+              cxx: cl,
+            }
+        ]
       fail-fast: false
 
     steps:
@@ -106,7 +113,7 @@ jobs:
     - name: Debug - Upload build artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.REPOSITORY_NAME }}-${{ env.LATEST_TAG }}-${{ runner.os }}-${{ env.COMPILER_NAME }}-${{ env.CMAKE_DEBUG_BUILD_PRESET_PUBLIC_NAME }}
+        name: ${{ env.REPOSITORY_NAME }}-${{ env.LATEST_TAG }}-${{ runner.os }}-${{ matrix.compiler.name }}-${{ env.CMAKE_DEBUG_BUILD_PRESET_PUBLIC_NAME }}
         path: ${{ env.CMAKE_DEBUG_OUTPUT_PATTERN }}
 
     - name: Release - Build
@@ -115,5 +122,5 @@ jobs:
     - name: Release - Upload build artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.REPOSITORY_NAME }}-${{ env.LATEST_TAG }}-${{ runner.os }}-${{ env.COMPILER_NAME }}-${{ env.CMAKE_RELEASE_BUILD_PRESET_PUBLIC_NAME }}
+        name: ${{ env.REPOSITORY_NAME }}-${{ env.LATEST_TAG }}-${{ runner.os }}-${{ matrix.compiler.name }}-${{ env.CMAKE_RELEASE_BUILD_PRESET_PUBLIC_NAME }}
         path: ${{ env.CMAKE_RELEASE_OUTPUT_PATTERN }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -104,8 +104,8 @@ jobs:
     - name: Configure CMake
       run: >
         cmake --preset ${{ env.CMAKE_CONFIGURE_PRESET_NAME }}
-        -DCMAKE_C_COMPILER=${{ env.COMPILER_CC }}
-        -DCMAKE_CXX_COMPILER=${{ env.COMPILER_CXX }}
+        -DCMAKE_C_COMPILER=${{ matrix.compiler.cc }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }}
 
     - name: Debug - Build
       run: cmake --build --preset ${{ env.CMAKE_DEBUG_BUILD_PRESET_NAME }} --parallel


### PR DESCRIPTION
The start point to use full C++20 in ssdk (and C++23-26 in subprojects).

GCC 12 (... `C++11`, `C++14`, `C++17`, `C++20`)
upgraded to
GCC 14 (+ full `C++20`, `C++23` & `C++26`)


Clang 11 (.. `C++11`, `C++14`, `C++17`)
upgraded to
Clang 20 (+ `C++20` fully (everything, but no complete standard of `module`s), `C++23` & `C++26` with more features)

MSVC has remained upstream, but partially supports `C++23`